### PR TITLE
Make the extra row of buttons look just like the keys on the keyboard

### DIFF
--- a/iVim/OptionalButton.swift
+++ b/iVim/OptionalButton.swift
@@ -45,7 +45,11 @@ class OptionalButton: UIView {
 extension OptionalButton {
     fileprivate func setup() {
         self.layer.backgroundColor = UIColor.white.cgColor
-        self.layer.cornerRadius = 4
+        self.layer.cornerRadius = 5
+        self.layer.shadowColor = UIColor.black.cgColor
+        self.layer.shadowOffset = CGSize(width: 0, height: 1)
+        self.layer.shadowOpacity = 0.4
+        self.layer.shadowRadius = 0
     }
 }
 

--- a/iVim/VimViewController+ExtendedKeyboard.swift
+++ b/iVim/VimViewController+ExtendedKeyboard.swift
@@ -130,8 +130,15 @@ extension VimViewController {
         let bar = OptionalButtonsBar(frame: CGRect(x: 0, y: 0, width: bounds.width, height: height))
         bar.autoresizingMask = [.flexibleWidth]
         bar.setButtons(with: self.buttons)
-        bar.backgroundColor = UIColor(white: 0.860, alpha: 1)
-        
+
+        // these magic numbers come from clicking "debug view hierarchy" and digging
+        // through the view hierarchy of the keyboard to find the background color
+        if UIDevice.current.systemVersion.compare("11.0", options: .numeric) == .orderedAscending {
+            bar.backgroundColor = UIColor(white: 0.83, alpha: 0.96)
+        } else {
+            bar.backgroundColor = UIColor(red: 0.827, green:0.845, blue:0.87, alpha: 1)
+        }
+
         return bar
     }
 }


### PR DESCRIPTION
I've tested this in the simulator on ios 9, 10, and 11, and it looks great.
![simulator screen shot - iphone x - 2018-04-26 at 17 30 32](https://user-images.githubusercontent.com/5678977/39338529-14a60ddc-4978-11e8-93e3-6d5f2e0f3b08.png)
