### PR TITLE
New Feature to map Ctrl to Esc on Release

### DIFF
--- a/iVim.xcodeproj/project.pbxproj
+++ b/iVim.xcodeproj/project.pbxproj
@@ -9203,7 +9203,7 @@
 					"$(PROJECT_DIR)/vim/src/iviminclude/**",
 				);
 				INFOPLIST_FILE = iVim/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -9242,7 +9242,7 @@
 					"$(PROJECT_DIR)/vim/src/iviminclude/**",
 				);
 				INFOPLIST_FILE = iVim/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iVim.xcodeproj/project.pbxproj
+++ b/iVim.xcodeproj/project.pbxproj
@@ -9203,7 +9203,7 @@
 					"$(PROJECT_DIR)/vim/src/iviminclude/**",
 				);
 				INFOPLIST_FILE = iVim/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",
@@ -9242,7 +9242,7 @@
 					"$(PROJECT_DIR)/vim/src/iviminclude/**",
 				);
 				INFOPLIST_FILE = iVim/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = (
 					"$(inherited)",

--- a/iVim/Settings.bundle/Root.plist
+++ b/iVim/Settings.bundle/Root.plist
@@ -92,6 +92,16 @@
 			<key>Type</key>
 			<string>PSToggleSwitchSpecifier</string>
 			<key>Title</key>
+			<string>Map [ctrl] to [esc] on release</string>
+			<key>Key</key>
+			<string>kUDCtrlToEscOnRelease</string>
+			<key>DefaultValue</key>
+			<false/>
+		</dict>
+		<dict>
+			<key>Type</key>
+			<string>PSToggleSwitchSpecifier</string>
+			<key>Title</key>
 			<string>Enable [alt] Mapping</string>
 			<key>Key</key>
 			<string>kUDOptionMapping</string>

--- a/iVim/Settings.bundle/Root.plist
+++ b/iVim/Settings.bundle/Root.plist
@@ -64,7 +64,7 @@
 			<key>Title</key>
 			<string>Hardware Keyboard</string>
 			<key>FooterText</key>
-			<string>Mapping caps lock has caveats. See &quot;:h ios-external-keyboard&quot;. Mapping [alt] enables iVim take over alt- keystrokes. Key Repeating repeats the held key for English keyboards.</string>
+			<string>Mapping caps lock has caveats. See &quot;:h ios-external-keyboard&quot;. Mapping [alt] enables iVim take over alt- keystrokes. Key Repeating repeats the held key for English keyboards. Mapping [ctrl] to [escape] on release only works in iOS 13.4 and above.</string>
 		</dict>
 		<dict>
 			<key>Type</key>

--- a/iVim/VimViewController+ExternalKeyboard.swift
+++ b/iVim/VimViewController+ExternalKeyboard.swift
@@ -121,13 +121,7 @@ extension VimViewController {
             modifierFlags: [.alphaShift])
     
     private static let ctrlToEscOnRelease: [UIKeyCommand] =
-        VimViewController.externalKeys +
-        VimViewController.optionKeys +
-        VimViewController.keyCommands(keys: alphabetaKeys, modifierFlags: [[]]) +
-        [VimViewController.keyCommand(input: "", modifierFlags: .control)] +
-        VimViewController.keyCommands(inputs: specialKeys, modifierFlags: [.control]) +
-        VimViewController.keyCommands(
-            keys: alphabetaKeys + numericKeys + symbolKeys + escapedKeys, modifierFlags: [.control])
+        [VimViewController.keyCommand(input: "", modifierFlags: .control)]
 
     private var isOptionMappingEnabled: Bool {
         return UserDefaults.standard.bool(forKey: kUDOptionMapping)
@@ -321,14 +315,13 @@ extension VimViewController {
             self.capsLockIsBeingPressed = true
             if self.currentCapslockDst == .ctrl {
                 self.ctrlPressed()
+            } else {
+              self.noKeyPressesSinceLastCtrlPress = false
             }
-            break
-        case .keyboardLeftControl:
-            self.ctrlPressed()
-        case .keyboardRightControl:
+        case .keyboardLeftControl, .keyboardRightControl:
             self.ctrlPressed()
         default:
-            break
+            self.noKeyPressesSinceLastCtrlPress = false
         }
     }
 
@@ -339,10 +332,7 @@ extension VimViewController {
             if self.currentCapslockDst == .ctrl {
                 self.maybeMapCtrlToEsc()
             }
-            break
-        case .keyboardLeftControl:
-            self.maybeMapCtrlToEsc()
-        case .keyboardRightControl:
+        case .keyboardLeftControl, .keyboardRightControl:
             self.maybeMapCtrlToEsc()
         default:
             break

--- a/iVim/VimViewController+ExternalKeyboard.swift
+++ b/iVim/VimViewController+ExternalKeyboard.swift
@@ -159,7 +159,14 @@ extension VimViewController {
     
     @objc func keyCommandTriggered(_ sender: UIKeyCommand) {
         DispatchQueue.main.async {
-            self.handleKeyCommand(sender)
+            var newModifierFlags = sender.modifierFlags
+            if self.capsLockIsBeingPressed {
+                newModifierFlags.formUnion(.alphaShift)
+            } else {
+                newModifierFlags.remove(.alphaShift)
+            }
+            let newCommand = VimViewController.keyCommand(input: sender.input ?? "", modifierFlags: newModifierFlags)
+            self.handleKeyCommand(newCommand)
         }
     }
         
@@ -266,5 +273,43 @@ extension VimViewController {
     override func selectAll(_ sender: Any?) {
         //handle <D-a>
         self.triggerReservedKeyCommand(input: "a", modifierFlags: .command)
+    }
+
+    override func pressesBegan(_ presses: Set<UIPress>,
+                               with event: UIPressesEvent?) {
+        super.pressesBegan(presses, with: event)
+        presses.first?.key.map(keyPressed)
+    }
+
+    override func pressesEnded(_ presses: Set<UIPress>,
+                               with event: UIPressesEvent?) {
+        super.pressesEnded(presses, with: event)
+        presses.first?.key.map(keyReleased)
+    }
+
+    override func pressesCancelled(_ presses: Set<UIPress>,
+                                   with event: UIPressesEvent?) {
+        super.pressesCancelled(presses, with: event)
+        presses.first?.key.map(keyReleased)
+    }
+
+    func keyPressed(_ key: UIKey) {
+        switch key.keyCode {
+        case .keyboardCapsLock:
+            self.capsLockIsBeingPressed = true
+            break
+        default:
+            break
+        }
+    }
+
+    func keyReleased(_ key: UIKey) {
+        switch key.keyCode {
+        case .keyboardCapsLock:
+            self.capsLockIsBeingPressed = false
+            break
+        default:
+            break
+        }
     }
 }

--- a/iVim/VimViewController+ExternalKeyboard.swift
+++ b/iVim/VimViewController+ExternalKeyboard.swift
@@ -170,14 +170,7 @@ extension VimViewController {
     
     @objc func keyCommandTriggered(_ sender: UIKeyCommand) {
         DispatchQueue.main.async {
-            var newModifierFlags = sender.modifierFlags
-            if self.capsLockIsBeingPressed {
-                newModifierFlags.formUnion(.alphaShift)
-            } else {
-                newModifierFlags.remove(.alphaShift)
-            }
-            let newCommand = VimViewController.keyCommand(input: sender.input ?? "", modifierFlags: newModifierFlags)
-            self.handleKeyCommand(newCommand)
+            self.handleKeyCommand(sender)
         }
     }
         
@@ -258,9 +251,7 @@ extension VimViewController {
             newInput = UIKeyCommand.inputEscape
         } else {
             if newInput.isEmpty { return }
-            if dst == .ctrl {
-                newModifierFlags.formUnion(.control)
-            }
+            newModifierFlags.formUnion(.control)
         }
         let newCommand = VimViewController.keyCommand(input: newInput, modifierFlags: newModifierFlags)
         self.handleKeyCommand(newCommand)
@@ -311,13 +302,6 @@ extension VimViewController {
 
     func keyPressed(_ key: UIKey) {
         switch key.keyCode {
-        case .keyboardCapsLock:
-            self.capsLockIsBeingPressed = true
-            if self.currentCapslockDst == .ctrl {
-                self.ctrlPressed()
-            } else {
-              self.noKeyPressesSinceLastCtrlPress = false
-            }
         case .keyboardLeftControl, .keyboardRightControl:
             self.ctrlPressed()
         default:
@@ -327,11 +311,6 @@ extension VimViewController {
 
     func keyReleased(_ key: UIKey) {
         switch key.keyCode {
-        case .keyboardCapsLock:
-            self.capsLockIsBeingPressed = false
-            if self.currentCapslockDst == .ctrl {
-                self.maybeMapCtrlToEsc()
-            }
         case .keyboardLeftControl, .keyboardRightControl:
             self.maybeMapCtrlToEsc()
         default:

--- a/iVim/VimViewController+ExternalKeyboard.swift
+++ b/iVim/VimViewController+ExternalKeyboard.swift
@@ -244,7 +244,9 @@ extension VimViewController {
             newInput = UIKeyCommand.inputEscape
         } else {
             if newInput.isEmpty { return }
-            newModifierFlags.formUnion(.control)
+            if dst == .ctrl {
+                newModifierFlags.formUnion(.control)
+            }
         }
         let newCommand = VimViewController.keyCommand(input: newInput, modifierFlags: newModifierFlags)
         self.handleKeyCommand(newCommand)

--- a/iVim/VimViewController+ExternalKeyboard.swift
+++ b/iVim/VimViewController+ExternalKeyboard.swift
@@ -301,8 +301,8 @@ extension VimViewController {
     func keyReleased() {
         if self.shouldMapCtrlToEscOnRelease && self.onlyCtrlIsBeingPressed {
             let newCommand = VimViewController.keyCommand(input: UIKeyCommand.inputEscape, modifierFlags: [])
-            self.onlyCtrlIsBeingPressed = false
             self.handleKeyCommand(newCommand)
         }
+        self.onlyCtrlIsBeingPressed = false
     }
 }

--- a/iVim/VimViewController.swift
+++ b/iVim/VimViewController.swift
@@ -98,7 +98,6 @@ final class VimViewController: UIViewController, UIKeyInput, UITextInput, UIText
     
     var currentPrimaryLanguage: String?
     
-    var capsLockIsBeingPressed = false
     var noKeyPressesSinceLastCtrlPress = false
 
     private func registerNotifications() {

--- a/iVim/VimViewController.swift
+++ b/iVim/VimViewController.swift
@@ -98,6 +98,8 @@ final class VimViewController: UIViewController, UIKeyInput, UITextInput, UIText
     
     var currentPrimaryLanguage: String?
     
+    var capsLockIsBeingPressed = false
+
     private func registerNotifications() {
         let nfc = NotificationCenter.default
         nfc.addObserver(self, selector: #selector(self.keyboardWillChangeFrame(_:)), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)

--- a/iVim/VimViewController.swift
+++ b/iVim/VimViewController.swift
@@ -99,6 +99,7 @@ final class VimViewController: UIViewController, UIKeyInput, UITextInput, UIText
     var currentPrimaryLanguage: String?
     
     var capsLockIsBeingPressed = false
+    var noKeyPressesSinceLastCtrlPress = false
 
     private func registerNotifications() {
         let nfc = NotificationCenter.default

--- a/iVim/VimViewController.swift
+++ b/iVim/VimViewController.swift
@@ -98,7 +98,7 @@ final class VimViewController: UIViewController, UIKeyInput, UITextInput, UIText
     
     var currentPrimaryLanguage: String?
     
-    var noKeyPressesSinceLastCtrlPress = false
+    var onlyCtrlIsBeingPressed = false
 
     private func registerNotifications() {
         let nfc = NotificationCenter.default


### PR DESCRIPTION
This adds a new app setting to map ctrl to esc on release. That is if ctrl (either physical or mapped by iVim/iOS) is pressed and released without any other keys pressed, it'll act as an escape key.